### PR TITLE
[MRG] Greater stationarity test precision

### DIFF
--- a/pmdarima/arima/tests/test_approx.py
+++ b/pmdarima/arima/tests/test_approx.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from pmdarima.arima.approx import approx, _regularize
 from pmdarima.utils.array import c
 from pmdarima.utils.testing import assert_raises
+from pmdarima.arima.stationarity import ADFTest
 
 from numpy.testing import assert_array_almost_equal
 import numpy as np
@@ -59,3 +60,20 @@ def test_corners():
 
     # fails for bad length
     assert_raises(ValueError, approx, x=[], y=[], xout=[], method='constant')
+
+
+def test_approx_precision():
+    # Test an example from R vs. Python to compare the expected values and
+    # make sure we get as close as possible. This is from an ADFTest where k=1
+    # and x=austres
+    tableipl = np.array([[-4.0664],
+                         [-3.7468],
+                         [-3.462],
+                         [-3.1572],
+                         [-1.2128],
+                         [-0.8928],
+                         [-0.6104],
+                         [-0.2704]])
+
+    _, interpol = approx(tableipl, ADFTest.tablep, xout=-1.337233, rule=2)
+    assert np.allclose(interpol, 0.84880354)  # in R we get 0.8488036

--- a/pmdarima/arima/utils.py
+++ b/pmdarima/arima/utils.py
@@ -148,6 +148,10 @@ def ndiffs(x, alpha=0.05, test='kpss', max_d=2, **kwargs):
         The estimated differencing term. This is the maximum value of ``d``
         such that ``d <= max_d`` and the time series is judged stationary.
         If the time series is constant, will return 0.
+
+    References
+    ----------
+    .. [1] R's auto_arima ndiffs function: https://bit.ly/2Bu8CHN
     """
     if max_d <= 0:
         raise ValueError('max_d must be a positive integer')


### PR DESCRIPTION
Issue #67 asked for clarification around the use of the stationarity tests in `pmdarima`. In the process of putting together an example, I found a slight bug in the way we compute `OLS` regression for the augmented Dickey-Fuller test, as well as several other opportunities for improvement. This PR achieves the following:

* Change the `OLS` fit method to use `'qr'` rather than `'pinv'`
* Use the `OLS` result wrapper `bse` attribute to access coefficient standard errors rather than the `H0_se` attribute
* Improve readability in the `KPSS` test
* Include links to R source code in the stationarity test docstrings
* Add several tests and more coverage