### PR TITLE
[MRG+1] Py37 build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ after_success:
   - source build_tools/travis/after_success.sh  # || echo "shell_session_update failed"
   # Build the wheels every time so we can debug
   - bash build_tools/travis/build_wheels.sh
-  - ls dist/
+  - bash build_tools/travis/after_wheel_build.sh
 
 # TODO: do we want "always?"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,8 @@ after_success:
   - source build_tools/travis/after_success.sh  # || echo "shell_session_update failed"
   # Build the wheels every time so we can debug
   - bash build_tools/travis/build_wheels.sh
+
+before_deploy:
   - bash build_tools/travis/after_wheel_build.sh
 
 # TODO: do we want "always?"

--- a/build_tools/travis/after_wheel_build.sh
+++ b/build_tools/travis/after_wheel_build.sh
@@ -7,7 +7,7 @@ if [[ "${DEPLOY}" != true ]]; then
 fi
 
 # Check for presence of wheel and tarball post-build
-if [[ ! -f dist/*.whl ]] && [[ ! -f dist/*.tar.gz ]]; then
+if [[ ! -f dist/*.whl && ! -f dist/*.tar.gz ]]; then
     echo "Artifacts did not build successfully"
     exit 1
 else

--- a/build_tools/travis/after_wheel_build.sh
+++ b/build_tools/travis/after_wheel_build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Don't think we actually need this, because we always build, but it doesn't hurt
+if [[ "${DEPLOY}" != true ]]; then
+    # Not a release
+    exit 0
+fi
+
+# Check for presence of wheel and tarball post-build
+if [[ ! -f dist/*.whl ]] && [[ ! -f dist/*.tar.gz ]]; then
+    echo "Artifacts did not build successfully"
+    exit 1
+else
+    echo "Build artifacts created successfully"
+fi

--- a/build_tools/travis/after_wheel_build.sh
+++ b/build_tools/travis/after_wheel_build.sh
@@ -7,9 +7,11 @@ if [[ "${DEPLOY}" != true ]]; then
 fi
 
 # Check for presence of wheel and tarball post-build
-if [[ ! -f dist/*.whl && ! -f dist/*.tar.gz ]]; then
-    echo "Artifacts did not build successfully"
-    exit 1
-else
+WHEEL=$(find dist/ -name '*.whl' | wc -l)
+TAR=$(find dist/ -name '*.tar.gz' | wc -l)
+if [[ ${WHEEL} -gt 0 && ${TAR} -gt 0 ]]; then
     echo "Build artifacts created successfully"
+else
+    echo "Build artifacts were not created. Skipping deployment..."
+    exit 1
 fi

--- a/build_tools/travis/build_manywheels_linux.sh
+++ b/build_tools/travis/build_manywheels_linux.sh
@@ -11,7 +11,7 @@ PIP="/opt/python/${PYTHON_VERSION}/bin/pip"
 # function from the package after 0.31.1 and it fails for Python 3.6?!
 ${PIP} install --upgrade pip wheel==0.31.1
 ${PIP} install --upgrade setuptools
-${PIP} install --upgrade cython==0.23.5
+${PIP} install --upgrade cython==0.27.2
 
 # One of our envs is not building correctly anymore. Need Numpy up front since
 # statsmodels 0.9.0 now requires numpy to install from pip

--- a/build_tools/travis/build_manywheels_linux.sh
+++ b/build_tools/travis/build_manywheels_linux.sh
@@ -11,7 +11,7 @@ PIP="/opt/python/${PYTHON_VERSION}/bin/pip"
 # function from the package after 0.31.1 and it fails for Python 3.6?!
 ${PIP} install --upgrade pip wheel==0.31.1
 ${PIP} install --upgrade setuptools
-${PIP} install --upgrade cython==0.27.2
+${PIP} install --upgrade cython
 
 # One of our envs is not building correctly anymore. Need Numpy up front since
 # statsmodels 0.9.0 now requires numpy to install from pip


### PR DESCRIPTION
This PR removes the explicit version for `cython`, which was preventing build artifacts for Python 3.7 (#76), and adds a check to make sure our build artifacts were created before deployment.

I added the check in the `before_deploy` section of the build as noted [here](https://docs.travis-ci.com/user/job-lifecycle/#deploying-your-code), so it will only get run on a tagged release (i.e., it won't run when we merge this in). I initially had it in the `after_success` phase, and I am more than happy to move it back, but it made more sense to me here.