### PR TITLE
[MRG] Improve codecov tolerance

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,24 @@
+# Prevent codecov from commenting
+comment: false
+
+# Opts scikit uses
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to master should not make the overall
+        # project coverage decrease by more than 1%:
+        target: auto
+        threshold: 1%
+
+    patch:
+      default:
+        # Be tolerant on slight code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        # in the github diff if they install the codecov browser
+        # extension:
+        # https://github.com/codecov/browser-extension
+        target: auto
+        threshold: 1%

--- a/doc/tips_and_tricks.rst
+++ b/doc/tips_and_tricks.rst
@@ -123,7 +123,7 @@ data in order to make it stationary, we can conduct an ADF test:
     # Test whether we should difference at the alpha=0.05
     # significance level
     adf_test = ADFTest(alpha=0.05)
-    p_val, should_diff = adf_test.is_stationary(y)  # (0.99, False)
+    p_val, should_diff = adf_test.is_stationary(y)  # (0.01, False)
 
 The verdict, per the ADF test, is that we should *not* difference. Pmdarima also
 provides a more handy interface for estimating your ``d`` parameter more directly:
@@ -207,7 +207,7 @@ Setting ``m``
 ~~~~~~~~~~~~~
 
 The ``m`` parameter is the number of observations per seasonal cycle, and is
-one that must be known apriori. Typically, ``m`` will correspond to some
+one that **must be known apriori**. Typically, ``m`` will correspond to some
 recurrent periodicity such as:
 
 * 7 - daily


### PR DESCRIPTION
Codecov fails out CI tests for virtually any decrement. This adds `.codecov.yml`, which sets the threshold allowance to 1%.