### PR TITLE
[MRG+1] Deprecate 'is_stationary'

### DIFF
--- a/doc/tips_and_tricks.rst
+++ b/doc/tips_and_tricks.rst
@@ -150,7 +150,7 @@ for more info. Here's an example of an ADF test:
     # Test whether we should difference at the alpha=0.05
     # significance level
     adf_test = ADFTest(alpha=0.05)
-    p_val, should_diff = adf_test.is_stationary(y)  # (0.01, False)
+    p_val, should_diff = adf_test.should_diff(y)  # (0.01, False)
 
 The verdict, per the ADF test, is that we should *not* difference. Pmdarima also
 provides a more handy interface for estimating your ``d`` parameter more directly.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,9 @@ v0.8.1) will document the latest features.
 
 * Add benchmarking notebook and capabilities in ``pytest`` plugins
 
+* Deprecate the ``is_stationary`` method in tests of stationarity. This will be removed in
+  v1.4.0. Use ``should_diff`` instead.
+
 
 `v1.1.0 <http://alkaline-ml.com/pmdarima/1.1.0/>`_
 --------------------------------------------------

--- a/pmdarima/arima/utils.py
+++ b/pmdarima/arima/utils.py
@@ -157,7 +157,7 @@ def ndiffs(x, alpha=0.05, test='kpss', max_d=2, **kwargs):
         raise ValueError('max_d must be a positive integer')
 
     # get the test
-    testfunc = get_callable(test, VALID_TESTS)(alpha, **kwargs).is_stationary
+    testfunc = get_callable(test, VALID_TESTS)(alpha, **kwargs).should_diff
     x = column_or_1d(check_array(x, ensure_2d=False,
                                  force_all_finite=True, dtype=DTYPE))
 


### PR DESCRIPTION
The tests of stationarity test currently use a function "`is_stationary`" to indicate whether we should difference the time series. However, the nomenclature is backwards. Since we've recently had an issue where someone requested clarification on the test (#67), it makes sense we should change this so it makes more intuitive sense.

### Changes

* Create new function, "`should_diff`", that replaces `is_stationary`
* If user calls `is_stationary`, raise a `DeprecationWarning` and internally delegate to `should_diff`

We'll remove the `is_stationary` function in 1.4.