### PR TITLE
Less appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,10 @@ environment:
       PYTHON: "C:\\Python37-x64"
       DO_TEST: "true"
 
+version: '{branch}-{build}'
+cache:
+  - C:\Users\appveyor\pip\wheels
+
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing
 # PR. The following option cancels pending jobs in a given PR after the first
@@ -106,7 +110,7 @@ test_script:
   # Test with pytest
   - ps: |
       if ($env:DO_TEST -Match "true") {
-        pytest --showlocals --durations=20 --mpl --mpl-baseline-path=pytest_images --pyargs pmdarima --benchmark-skip"
+        pytest --showlocals --durations=20 --mpl --mpl-baseline-path=pytest_images --pyargs pmdarima --benchmark-skip
       } else {
         echo "Not running tests since DO_TEST is not 'true'"
       }
@@ -122,10 +126,3 @@ deploy_script:
   - set PATH=%BK_PATH%
   - ps: If ($env:APPVEYOR_REPO_TAG -eq "true") { Invoke-Expression "twine upload -u tgsmith61591.gh -p $env:PYPI_PASSWORD --skip-existing dist/*" } Else { write-output "Not on a tagged commit, won't deploy to pypi"}
   #- ps: If ($env:APPVEYOR_REPO_BRANCH -eq "develop") { Invoke-Expression "twine upload -u tgsmith61591.gh -p $env:PYPI_PASSWORD --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*" } Else { write-output "Not on a development commit, won't deploy to pypitest"}
-
-cache:
-  # Use the appveyor cache to avoid re-downloading large archives such
-  # the MKL numpy and scipy wheels mirrored on a rackspace cloud
-  # container, speed up the appveyor jobs and reduce bandwidth
-  # usage on our rackspace account.
-  - '%APPDATA%\pip\Cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,42 +14,52 @@ environment:
   PYPI_PASSWORD:
     secure: okvMa3VgIXdlnMC48iMefQ==
 
+  # For deployments, we have to build on the architecture we want to ship.
+  # However, since there are so many and appveyor doesn't run in parallel,
+  # we don't need to run tests for all of them. We can just build some for
+  # deployments.
   matrix:
     - PYTHON_ARCH: "32"
       PYTHON_VERSION: "3.5.1"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python35"
+      DO_TEST: "false"
 
     - PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.5.1"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python35-x64"
+      DO_TEST: "true"
 
     - PYTHON_ARCH: "32"
       PYTHON_VERSION: "3.6.6"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python36"
+      DO_TEST: "true"
 
     - PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.6.6"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python36-x64"
+      DO_TEST: "false"
 
     - PYTHON_ARCH: "32"
       PYTHON_VERSION: "3.7.0"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python37"
+      DO_TEST: "false"
 
     - PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.7.0"
       MPL_VERSION: "2.2.3"
       PMDARIMA_MPL_DEBUG: "true"
       PYTHON: "C:\\Python37-x64"
+      DO_TEST: "true"
 
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing
@@ -94,7 +104,12 @@ build: false
 
 test_script:
   # Test with pytest
-  - "pytest --showlocals --durations=20 --mpl --mpl-baseline-path=pytest_images --pyargs pmdarima --benchmark-skip"
+  - ps: |
+      if ($env:DO_TEST -Match "true") {
+        pytest --showlocals --durations=20 --mpl --mpl-baseline-path=pytest_images --pyargs pmdarima --benchmark-skip"
+      } else {
+        echo "Not running tests since DO_TEST is not 'true'"
+      }
 
 after_test:
   - set PATH=%BK_PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ environment:
 version: '{branch}-{build}'
 cache:
   - C:\Users\appveyor\pip\wheels
+  - '%APPDATA%\pip\Cache'
 
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,9 @@ environment:
 
 version: '{branch}-{build}'
 cache:
-  - C:\Users\appveyor\pip\wheels
   - '%APPDATA%\pip\Cache'
+  # - C:\Users\appveyor\pip\wheels
+  # - ~\AppData\Local\pip\cache
 
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing

--- a/build_tools/circle/build_test_pypy.sh
+++ b/build_tools/circle/build_test_pypy.sh
@@ -17,11 +17,15 @@ python --version
 which python
 
 # This is a temporary fix for #93:
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu numpy==1.15
-pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu Cython pytest pytest-mpl pytest-benchmark
+# XXX: numpy version pinning can be reverted once PyPy
+#      compatibility is resolved for numpy v1.6.x. For instance,
+#      when PyPy3 >6.0 is released (see numpy/numpy#12740)
+pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu numpy=="1.15.*" Cython pytest
 pip install "scipy>=1.1.0"
-pip install "scikit-learn==0.19.1"
-pip install pandas statsmodels matplotlib
+pip install "scikit-learn==0.19.*"
+# Pandas has starting throwing issues in Pypy now...
+pip install "pandas==0.23.*" statsmodels matplotlib
+pip install --extra-index https://antocuni.github.io/pypy-wheels/ubuntu pytest-mpl pytest-benchmark
 
 ccache -M 512M
 export CCACHE_COMPRESS=1


### PR DESCRIPTION
Our Appveyor builds are prohibitively slow. We still need all jobs to run since for deployments the wheel has to be built on the appropriate architecture... but we don't always have to run tests.

This PR removes half of the test jobs, just letting the wheels build. It also adds in some more pip caching, although I'm wary as to whether it's actually working properly or not.

#### Bonus

Fix more pypy breakage on Circle. Any subsequent PR will have to rebase off these changes once they make it into `develop`