### PR TITLE
[MRG+1] Appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ environment:
 
 version: '{branch}-{build}'
 cache:
-  - '%APPDATA%\pip\Cache'
+  - '%LOCALAPPDATA%\pip\Cache'
   # - C:\Users\appveyor\pip\wheels
   # - ~\AppData\Local\pip\cache
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
-    APPVEYOR_SAVE_CACHE_ON_ERROR: true
+#    APPVEYOR_SAVE_CACHE_ON_ERROR: true
   PYPI_USERNAME: tgsmith61591.gh
   PYPI_PASSWORD:
     secure: okvMa3VgIXdlnMC48iMefQ==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
-#    APPVEYOR_SAVE_CACHE_ON_ERROR: true
   PYPI_USERNAME: tgsmith61591.gh
   PYPI_PASSWORD:
     secure: okvMa3VgIXdlnMC48iMefQ==
@@ -65,8 +64,6 @@ environment:
 version: '{branch}-{build}'
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
-  # - C:\Users\appveyor\pip\wheels
-  # - ~\AppData\Local\pip\cache
 
 # Because we only have a single worker, we don't want to waste precious
 # appveyor CI time and make other PRs wait for repeated failures in a failing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
   PYPI_USERNAME: tgsmith61591.gh
   PYPI_PASSWORD:
     secure: okvMa3VgIXdlnMC48iMefQ==


### PR DESCRIPTION
This PR addresses #98

We can see the cache is [being used](https://ci.appveyor.com/project/tgsmith61591/pmdarima/builds/22262043/job/qnv2fie979qkav4t#L32) and [being updated](https://ci.appveyor.com/project/tgsmith61591/pmdarima/builds/22262043/job/qnv2fie979qkav4t#L695). I don't know how much time is really being saved (my builds were still taking ~12 minutes). The only additional change we might want to add is to [skip updating cache unless we are on a specific branch](https://www.appveyor.com/docs/build-cache/#skipping-cache-operations-for-specific-build), but I was watching these build in real time, and that step only took like 1 second each.