### PR TITLE
[MRG+1] Store OOB preds

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,6 +30,9 @@ v0.8.1) will document the latest features.
 
 * Added two new datasets: ``airpassengers`` & ``austres``
 
+* When using ``out_of_sample``, the out-of-sample predictions are now stored
+  under the ``oob_preds_`` attribute.
+
 
 `v1.1.1 <http://alkaline-ml.com/pmdarima/1.1.1/>`_
 --------------------------------------------------

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -207,6 +207,19 @@ class ARIMA(BaseEstimator):
     with_intercept : bool, optional (default=True)
         Whether to include an intercept term. Default is True.
 
+    Attributes
+    ----------
+    model_res_ : ModelResultsWrapper
+        The model results, per statsmodels
+
+    oob_ : float
+        The MAE or MSE of the out-of-sample records, if ``out_of_sample_size``
+        is > 0, else np.nan
+
+    oob_preds_ : np.ndarray or None
+        The predictions for the out-of-sample records, if
+        ``out_of_sample_size`` is > 0, else None
+
     Notes
     -----
     * Since the ``ARIMA`` class currently wraps

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -424,6 +424,7 @@ class ARIMA(BaseEstimator):
             # from statsmodels internally)
             pred = self.predict(n_periods=cv, exogenous=cv_exog)
             self.oob_ = scoring(cv_samples, pred, **self.scoring_args)
+            self.oob_preds_ = pred
 
             # If we compute out of sample scores, we have to now update the
             # observed time points so future forecasts originate from the end
@@ -431,6 +432,7 @@ class ARIMA(BaseEstimator):
             self.update(cv_samples, cv_exog, **fit_args)
         else:
             self.oob_ = np.nan
+            self.oob_preds_ = None
 
         return self
 


### PR DESCRIPTION
#111 asked how to access OOB predictions when ``out_of_sample_size > 0``. This PR stores the attribute.