### PR TITLE
[MRG+1] Fix deploy logic on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,12 +91,8 @@ jobs:
     # Use this one for testing: python -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/pmdarima-*
   - script: python -m twine upload --skip-existing dist/pmdarima-*
     displayName: 'Deploying to PyPI'
-    # Only deploy if this is a tagged commit on master
-    condition: |
-      and(
-        eq(variables['Build.SourceBranchName'], 'master'),
-        contains(variables['Build.SourceBranch'], 'tags')
-      )
+    # Only deploy if this is a tagged commit
+    condition: contains(variables['Build.SourceBranch'], 'tags')
     env:
       TWINE_USERNAME: $(twineUsername)
       TWINE_PASSWORD: $(twinePassword)


### PR DESCRIPTION
After doing [a little research](https://stackoverflow.com/a/27154277), and [reading the docs a little bit more](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables), I found that `Build.SourceBranch` would resolve to `refs/tags/<tag>`, and `Build.SourceBranchName` would just resolve to `<tag>`, so the deploy step would fail. I removed the condition that the tag must be on `master`, because as my first link shows, tags and branches are entirely independent.