### PR TITLE
[MRG+1] SARIMAX only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,3 +22,13 @@ coverage:
         # https://github.com/codecov/browser-extension
         target: auto
         threshold: 1%
+
+ignore:
+- "**/setup.py"
+- "*/pmdarima/__check_build/*"
+- "*/pmdarima/_build_utils/*"
+- "*/pmdarima/_config.py"
+- "*/pmdarima/__init__.py"
+- "*/pmdarima/compat/matplotlib.py"
+- "*/pmdarima/utils/tests/test_vis.py"
+- "*/pmdarima/utils/visualization.py"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 ## Authors
 
-The following people have been core contributors to `pyramid`'s development:
+The following people have been core contributors to `pmdarima`'s development:
 
   * [Taylor Smith](https://github.com/tgsmith61591)
   * [Gary Foreman](https://github.com/garyForeman)
@@ -10,6 +10,6 @@ The following people have been core contributors to `pyramid`'s development:
   * [Krishna Sunkara](https://github.com/kpsunkara)
 
 __Please do not email the authors directly with questions or issues.__ Rather, use
-the [issues](https://github.com/tgsmith61591/pyramid/issues) page. Furthermore, issues
+the [issues](https://github.com/tgsmith61591/pmdarima/issues) page. Furthermore, issues
 or emails specifically related to assistance in learning time series analysis should be
 saved for Stack Overflow.

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ test-lint: test-requirements
 	$(PYTHON) -m flake8 pmdarima --filename='*.py' --ignore E803,F401,F403,W293,W504
 
 test-unit: test-requirements coverage-dependencies
-	$(PYTHON) -m pytest -v --durations=20 --mpl --mpl-baseline-path=etc/pytest_images --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-skip
+	$(PYTHON) -m pytest -v --durations=20 --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-skip
 
 test-benchmark: test-requirements coverage-dependencies
-	$(PYTHON) -m pytest -v --durations=12 --mpl --mpl-baseline-path=etc/pytest_images --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-min-rounds=5 --benchmark-min-time=1 --benchmark-only
+	$(PYTHON) -m pytest -v --durations=12 --cov-config .coveragerc --cov pmdarima -p no:logging --benchmark-min-rounds=5 --benchmark-min-time=1 --benchmark-only
 
 test: develop test-unit test-lint
 	# Coverage creates all these random little artifacts we don't want

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,6 +47,7 @@ Other versions
 
 Documentation for other release versions of ``pmdarima``:
 
+* `v1.5.0 <http://alkaline-ml.com/pmdarima/1.5.0>`_
 * `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0>`_
 * `v1.3.0 <http://alkaline-ml.com/pmdarima/1.3.0>`_
 * `v1.2.0 <http://alkaline-ml.com/pmdarima/1.2.0>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,11 +11,18 @@ v0.8.1) will document the latest features.
 `v1.5.0 <http://alkaline-ml.com/pmdarima/1.5.0/>`_
 --------------------------------------------------
 
-* Defaults that have changed:
+* No longer use statsmodels' ``ARIMA`` or ``ARMA`` class under the hood; only use
+  the ``SARIMAX`` model, which cuts back on a lot of errors/warnings we saw in the past.
+  (`#211 <https://github.com/tgsmith61591/pmdarima/issues/211>`_)
+
+* Defaults in the ``ARIMA`` class that have changed as a result:
 
   - ``maxiter`` is now 50 (was ``None``)
   - ``method`` is now 'lbfgs' (was ``None``)
   - ``seasonal_order`` is now ``(0, 0, 0, 0)`` (was ``None``)
+
+* Correct bug where ``aicc`` always added 1 (for constant) to degrees of freedom,
+  even when ``df_model`` accounted for the constant term.
 
 
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,16 @@ As new releases of pmdarima are pushed out, the following list (introduced in
 v0.8.1) will document the latest features.
 
 
+`v1.5.0 <http://alkaline-ml.com/pmdarima/1.5.0/>`_
+--------------------------------------------------
+
+* Defaults that have changed:
+
+  - ``maxiter`` is now 50 (was ``None``)
+  - ``method`` is now 'lbfgs' (was ``None``)
+  - ``seasonal_order`` is now ``(0, 0, 0, 0)`` (was ``None``)
+
+
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_
 --------------------------------------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,6 +24,9 @@ v0.8.1) will document the latest features.
 * Correct bug where ``aicc`` always added 1 (for constant) to degrees of freedom,
   even when ``df_model`` accounted for the constant term.
 
+* New :class:`pmdarima.arima.auto.StepwiseContext` feature for more control over
+  fit duration (introduced by `@kpsunkara <https://github.com/kpsunkara>`_ in `#221 <https://github.com/tgsmith61591/pmdarima/pull/221>`_).
+
 
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_
 --------------------------------------------------

--- a/examples/example_pipeline.py
+++ b/examples/example_pipeline.py
@@ -62,12 +62,11 @@ in_sample_preds, in_sample_confint = \
     pipe.predict_in_sample(exogenous=None, return_conf_int=True)
 
 n_train = train.shape[0]
-d = pipe._final_estimator.model_.order[1]
 
 x0 = np.arange(n_train)
 axes[0].plot(x0, train, alpha=0.75)
-axes[0].scatter(x0[d:], in_sample_preds, alpha=0.4, marker='x')
-axes[0].fill_between(x0[d:], in_sample_confint[:, 0], in_sample_confint[:, 1],
+axes[0].scatter(x0, in_sample_preds, alpha=0.4, marker='x')
+axes[0].fill_between(x0, in_sample_confint[:, 0], in_sample_confint[:, 1],
                      alpha=0.1, color='b')
 axes[0].set_title('Actual train samples vs. in-sample predictions')
 axes[0].set_xlim((0, x0.shape[0]))

--- a/examples/example_simple_fit.py
+++ b/examples/example_simple_fit.py
@@ -26,6 +26,7 @@ train, test = data[:150], data[150:]
 
 # Fit a simple auto_arima model
 arima = pm.auto_arima(train, error_action='ignore', trace=1,
+                      suppress_warnings=True,
                       seasonal=True, m=12)
 
 # #############################################################################

--- a/pmdarima/__init__.py
+++ b/pmdarima/__init__.py
@@ -46,7 +46,7 @@ else:
     from . import __check_build
 
     # Stuff we want at top-level
-    from .arima import auto_arima, ARIMA, AutoARIMA
+    from .arima import auto_arima, ARIMA, AutoARIMA, StepwiseContext
     from .utils import acf, autocorr_plot, c, pacf, plot_acf, plot_pacf
 
     # Need these namespaces at the top so they can be used like:
@@ -72,7 +72,8 @@ else:
         'c',
         'pacf',
         'plot_acf',
-        'plot_pacf'
+        'plot_pacf',
+        'StepwiseContext',
     ]
 
     # Delete unwanted variables from global

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -158,6 +158,17 @@ class _StepwiseFitWrapper(object):
         while self.start_k < self.k < self.max_k:
             self.start_k = self.k
 
+            # break loop if execution time exceeds the timeout threshold. needs
+            # to be at front of loop, since a single pass may reach termination
+            # criteria by end and we only want to warn and break if the loop is
+            # continuing again
+            dur = (datetime.now() - start_time).total_seconds()
+            if self.max_dur and dur > self.max_dur:
+                warnings.warn('early termination of stepwise search due to '
+                              'max_dur threshold (%.3f > %.3f)'
+                              % (dur, self.max_dur))
+                break
+
             # Each of these fit the models for an expression, a new p,
             # q, P or Q, and then reset best models
             # This takes the place of a lot of copy/pasted code....
@@ -192,13 +203,7 @@ class _StepwiseFitWrapper(object):
                                            self.p < self.max_p, q=self.q + 1,
                                            p=self.p + 1)
 
-            # break loop if execution time exceeds the timeout threshold
-            dur = (datetime.now() - start_time).total_seconds()
-            if self.max_dur and dur > self.max_dur:
-                warnings.warn('early termination of stepwise search due to '
-                              'max_dur threshold')
-                break
-
+        # TODO: @kpsunkara, should we return here?
         # check if the search has been ended after max_steps
         if self.exec_context.max_steps is not None \
                 and self.k > self.exec_context.max_steps:

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -117,7 +117,7 @@ class _StepwiseFitWrapper(object):
         Q = self.Q if Q is None else Q
 
         order = (p, self.d, q)
-        ssnl = (P, self.D, Q, self.m) if self.seasonal else None
+        ssnl = (P, self.D, Q, self.m) if self.seasonal else (0, 0, 0, 0)
 
         # if the sum of the orders > max_order we do not build this model...
         order_sum = p + q + (P + Q if self.seasonal else 0)
@@ -252,8 +252,7 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
 def _fmt_order_info(order, seasonal_order):
     return 'order=(%i, %i, %i)%s' \
            % (order[0], order[1], order[2],
-              '' if seasonal_order is None
-              else ' seasonal_order=(%i, %i, %i, %i)'
+              ' seasonal_order=(%i, %i, %i, %i)'
               % (seasonal_order[0], seasonal_order[1],
                  seasonal_order[2], seasonal_order[3]))
 

--- a/pmdarima/arima/_context.py
+++ b/pmdarima/arima/_context.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# re-entrant, reusable context manager to store execution context
+# Author: Krishna Sunkara (kpsunkara)
 #
+# Re-entrant, reusable context manager to store execution context. Introduced
+# in pmdarima 1.5.0 (see #221)
 
 import threading
 from abc import ABC, abstractmethod
@@ -18,8 +20,7 @@ __all__ = ['AbstractContext', 'ContextStore', 'ContextType']
 class ContextType(Enum):
     """Context Type Enumeration
 
-    An enumeration of Context Types known to ``ContextStore``
-
+    An enumeration of Context Types known to :class:`ContextStore`
     """
     EMPTY = 0
     STEPWISE = 1
@@ -32,7 +33,6 @@ class AbstractContext(ABC):
     execution context in a threading.local instance. Has helper
     methods to iterate over the context info and provide a
     string representation of the context info.
-
     """
     def __init__(self, **kwargs):
         # remove None valued entries,
@@ -81,9 +81,7 @@ class AbstractContext(ABC):
 
 
 class _emptyContext(AbstractContext):
-    """An empty context for convenience use
-
-    """
+    """An empty context for convenience use"""
 
     def __init__(self):
         super(_emptyContext, self).__init__()
@@ -102,8 +100,15 @@ class ContextStore:
     def get_context(context_type):
         """Returns most recently added instance of given Context Type
 
-        :param context_type: Context Type to retrieve from the store
-        :return: an instance of AbstractContext subclass or None
+        Parameters
+        ----------
+        context_type : ContextType
+            Context type to retrieve from the store
+
+        Returns
+        -------
+        res: AbstractContext
+            An instance of AbstractContext subclass or None
         """
         if not isinstance(context_type, ContextType):
             raise ValueError('context_type must be an instance of ContextType')
@@ -165,10 +170,6 @@ class ContextStore:
         ...         auto_arima(samp,...)
         ...
         ...     auto_arima(samp,...)
-
-
-        :param ctx:
-        :return: None
         """
         if not isinstance(ctx, AbstractContext):
             raise ValueError('ctx must be be an instance of AbstractContext')

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -147,15 +147,11 @@ _AUTO_ARIMA_DOCSTR = \
         Uses the transformation suggested in Jones (1980).  If False,
         no checking for stationarity or invertibility is done.
 
-    method : str, one of ('css-mle','mle','css'), optional (default=None)
-        This is the loglikelihood to maximize.  If "css-mle", the
-        conditional sum of squares likelihood is maximized and its values
-        are used as starting values for the computation of the exact
-        likelihood via the Kalman filter.  If "mle", the exact likelihood
-        is maximized via the Kalman Filter.  If "css" the conditional sum
-        of squares likelihood is maximized.  All three methods use
-        `start_params` as starting parameters.  See above for more
-        information. If fitting a seasonal ARIMA, the default is 'lbfgs'
+    method : str, optional (default='lbfgs')
+        One of ('newton', 'bfgs', 'lbfgs', 'powell', 'cg', 'ncg',
+        'basinhopping'). Determines a solver method for maximizing the
+        loglikelihood. Default is 'lbfgs' (limited-memory BFGS with optional
+        box constraints).
 
     trend : str or None, optional (default=None)
         The trend parameter. If ``with_intercept`` is True, ``trend`` will be
@@ -171,11 +167,8 @@ _AUTO_ARIMA_DOCSTR = \
         approximate the Hessian, projected gradient tolerance of 1e-8 and
         factr = 1e2. You can change these by using kwargs.
 
-    maxiter : int, optional (default=None)
-        The maximum number of function evaluations. Statsmodels defaults this
-        value to 50 for SARIMAX models and 500 for ARIMA and ARMA models. If
-        passed as None, will use the seasonal order to determine which to use
-        (50 for seasonal, 500 otherwise).
+    maxiter : int, optional (default=50)
+        The maximum number of function evaluations. Default is 50.
 
     disp : int, optional (default=0)
         If True, convergence information is printed.  For the default

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -266,7 +266,7 @@ class ARIMA(BaseARIMA):
 
     Notes
     -----
-    * The model internally wraps the statsmodels `SARIMAX class <https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html>`_  #noqa: E501
+    * The model internally wraps the statsmodels `SARIMAX class <https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html>`_  # noqa: E501
     * After the model fit, many more methods will become available to the
       fitted model (i.e., :func:`pvalues`, :func:`params`, etc.). These are
       delegate methods which wrap the internal ARIMA results instance.
@@ -812,6 +812,7 @@ class ARIMA(BaseARIMA):
         """
         return self.arima_res_.aic
 
+    # TODO: this looks like it's implemented on statsmodels' master
     @if_has_delegate('arima_res_')
     def aicc(self):
         """Get the AICc, the corrected Akaike Information Criterion:

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -46,9 +46,9 @@ class AutoARIMA(BaseARIMA):
                  max_D=1, max_Q=2, max_order=10, m=1, seasonal=True,
                  stationary=False, information_criterion='aic', alpha=0.05,
                  test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
-                 start_params=None, trend=None, method=None, transparams=True,
-                 solver='lbfgs', maxiter=None, disp=0, callback=None,
-                 offset_test_args=None, seasonal_test_args=None,
+                 start_params=None, trend=None, method='lbfgs',
+                 transparams=True, solver='lbfgs', maxiter=50, disp=0,
+                 callback=None, offset_test_args=None, seasonal_test_args=None,
                  suppress_warnings=False, error_action='warn', trace=False,
                  random=False, random_state=None, n_fits=10,
                  out_of_sample_size=0, scoring='mse',
@@ -236,8 +236,8 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                max_D=1, max_Q=2, max_order=10, m=1, seasonal=True,
                stationary=False, information_criterion='aic', alpha=0.05,
                test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
-               start_params=None, trend=None, method=None, transparams=True,
-               solver='lbfgs', maxiter=None, disp=0, callback=None,
+               start_params=None, trend=None, method='lbfgs', transparams=True,
+               solver='lbfgs', maxiter=50, disp=0, callback=None,
                offset_test_args=None, seasonal_test_args=None,
                suppress_warnings=False, error_action='warn', trace=False,
                random=False, random_state=None, n_fits=10,
@@ -317,7 +317,8 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         warnings.warn('Input time-series is completely constant; '
                       'returning a (0, 0, 0) ARMA.')
         return _return_wrapper(_post_ppc_arima(
-            _fit_arima(y, xreg=exogenous, order=(0, 0, 0), seasonal_order=None,
+            _fit_arima(y, xreg=exogenous, order=(0, 0, 0),
+                       seasonal_order=(0, 0, 0, 0),
                        start_params=start_params, trend=trend, method=method,
                        transparams=transparams, solver=solver, maxiter=maxiter,
                        disp=disp, callback=callback, fit_params=fit_args,
@@ -452,7 +453,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                              'suitable for ARIMA modeling')
 
         # perfect regression
-        ssn = None if not seasonal else (0, D, 0, m)
+        ssn = (0, 0, 0, 0) if not seasonal else (0, D, 0, m)
         return _return_wrapper(
             _post_ppc_arima(
                 _fit_arima(y, xreg=exogenous, order=(0, d, 0),
@@ -496,7 +497,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
     else:
         # otherwise it's not seasonal, and we don't need the seasonal pieces
         gen = (
-            ((p, d, q), None)
+            ((p, d, q), (0, 0, 0, 0))
             for p in xrange(start_p, max_p + 1)
             for q in xrange(start_q, max_q + 1)
             if p + q <= max_order

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -4,8 +4,6 @@
 #
 # Automatically find optimal parameters for an ARIMA
 
-from __future__ import absolute_import
-
 from joblib import Parallel, delayed
 import numpy as np
 from sklearn.utils import check_random_state
@@ -18,9 +16,10 @@ from . import _doc
 from .utils import ndiffs, is_constant, nsdiffs
 from ..utils import diff, is_iterable, check_endog
 from ..utils.metaestimators import if_has_delegate
-from ._auto_solvers import _fit_arima, _StepwiseFitWrapper
 from .warnings import ModelFitWarning
 from ._context import AbstractContext, ContextType
+# Import as a namespace so we can mock
+from . import _auto_solvers as solvers
 # for python 3 compat
 from ..compat.python import xrange
 from ..compat.numpy import DTYPE
@@ -175,20 +174,19 @@ class AutoARIMA(BaseARIMA):
 
 
 class StepwiseContext(AbstractContext):
-    """Context Manager to capture runtime context for Stepwise mode.
+    """Context manager to capture runtime context for stepwise mode.
 
-    ``StepwiseContext`` allows to call ``auto_arima`` in the context
+    ``StepwiseContext`` allows one to call :func:`auto_arima` in the context
     of a runtime configuration that offers additional level of
     control required in certain scenarios. Use cases that are either
     sensitive to duration and/or the number of attempts to
     find the best fit can use ``StepwiseContext`` to control them.
-    .
 
     Parameters
     ----------
     max_steps : int, optional (default=100)
         The maximum number of steps to try to find a best fit. When
-        the number of tries exceed this number, the stepwiese process
+        the number of tries exceed this number, the stepwise process
         will stop and the best fit model at that time will be returned.
 
     max_dur : int, optional (default=None)
@@ -197,16 +195,16 @@ class StepwiseContext(AbstractContext):
         stepwiese process will stop and the best fit model at that
         time will be returned. Please note that this is a soft limit.
 
-    notes
+    Notes
     -----
-    Although the max_steps parameter is set to a default value of None here,
-    the stepwise search is limited to 100 tries to find a best fit model.
-    Defaulting the parameter to None here, preserves the intention of the
+    Although the ``max_steps`` parameter is set to a default value of None
+    here, the stepwise search is limited to 100 tries to find a best fit model.
+    Defaulting the parameter to None here preserves the intention of the
     caller and properly handles the nested contexts, like:
 
     >>> with StepwiseContext(max_steps=10):
     ...     with StepwiseContext(max_dur=30):
-    ...         auto_arima(sample, stepwise=True, ..)
+    ...         auto_arima(sample, stepwise=True, ...)
 
     In the above example, the stepwise search will be limited to either
     a maximum of 10 steps or a maximum duration of 30 seconds, whichever
@@ -214,6 +212,7 @@ class StepwiseContext(AbstractContext):
     """
 
     def __init__(self, max_steps=None, max_dur=None):
+        # TODO: do we want an upper limit on this?
         if max_steps is not None and not 0 < max_steps <= 1000:
             raise ValueError('max_steps should be between 1 and 1000')
 
@@ -317,17 +316,18 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         warnings.warn('Input time-series is completely constant; '
                       'returning a (0, 0, 0) ARMA.')
         return _return_wrapper(_post_ppc_arima(
-            _fit_arima(y, xreg=exogenous, order=(0, 0, 0),
-                       seasonal_order=(0, 0, 0, 0),
-                       start_params=start_params, trend=trend, method=method,
-                       transparams=transparams, solver=solver, maxiter=maxiter,
-                       disp=disp, callback=callback, fit_params=fit_args,
-                       suppress_warnings=suppress_warnings, trace=trace,
-                       error_action=error_action, scoring=scoring,
-                       out_of_sample_size=out_of_sample_size,
-                       scoring_args=scoring_args,
-                       with_intercept=with_intercept,
-                       **sarimax_kwargs)),
+            solvers._fit_arima(
+                y, xreg=exogenous, order=(0, 0, 0),
+                seasonal_order=(0, 0, 0, 0),
+                start_params=start_params, trend=trend, method=method,
+                transparams=transparams, solver=solver, maxiter=maxiter,
+                disp=disp, callback=callback, fit_params=fit_args,
+                suppress_warnings=suppress_warnings, trace=trace,
+                error_action=error_action, scoring=scoring,
+                out_of_sample_size=out_of_sample_size,
+                scoring_args=scoring_args,
+                with_intercept=with_intercept,
+                **sarimax_kwargs)),
             return_valid_fits, start, trace)
 
     # test ic, and use AIC if n <= 3
@@ -456,21 +456,22 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         ssn = (0, 0, 0, 0) if not seasonal else (0, D, 0, m)
         return _return_wrapper(
             _post_ppc_arima(
-                _fit_arima(y, xreg=exogenous, order=(0, d, 0),
-                           seasonal_order=ssn,
-                           start_params=start_params, trend=trend,
-                           method=method, transparams=transparams,
-                           solver=solver, maxiter=maxiter,
-                           disp=disp, callback=callback,
-                           fit_params=fit_args,
-                           suppress_warnings=suppress_warnings,
-                           trace=trace,
-                           error_action=error_action,
-                           scoring=scoring,
-                           out_of_sample_size=out_of_sample_size,
-                           scoring_args=scoring_args,
-                           with_intercept=with_intercept,
-                           **sarimax_kwargs)),
+                solvers._fit_arima(
+                    y, xreg=exogenous, order=(0, d, 0),
+                    seasonal_order=ssn,
+                    start_params=start_params, trend=trend,
+                    method=method, transparams=transparams,
+                    solver=solver, maxiter=maxiter,
+                    disp=disp, callback=callback,
+                    fit_params=fit_args,
+                    suppress_warnings=suppress_warnings,
+                    trace=trace,
+                    error_action=error_action,
+                    scoring=scoring,
+                    out_of_sample_size=out_of_sample_size,
+                    scoring_args=scoring_args,
+                    with_intercept=with_intercept,
+                    **sarimax_kwargs)),
             return_valid_fits, start, trace)
 
     # seasonality issues
@@ -514,19 +515,20 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
 
         # get results in parallel
         all_res = Parallel(n_jobs=n_jobs)(
-            delayed(_fit_arima)(y, xreg=exogenous, order=order,
-                                seasonal_order=seasonal_order,
-                                start_params=start_params, trend=trend,
-                                method=method, transparams=transparams,
-                                solver=solver, maxiter=maxiter, disp=disp,
-                                callback=callback,
-                                fit_params=fit_args,
-                                suppress_warnings=suppress_warnings,
-                                trace=trace, error_action=error_action,
-                                out_of_sample_size=out_of_sample_size,
-                                scoring=scoring, scoring_args=scoring_args,
-                                with_intercept=with_intercept,
-                                **sarimax_kwargs)
+            delayed(solvers._fit_arima)(
+                y, xreg=exogenous, order=order,
+                seasonal_order=seasonal_order,
+                start_params=start_params, trend=trend,
+                method=method, transparams=transparams,
+                solver=solver, maxiter=maxiter, disp=disp,
+                callback=callback,
+                fit_params=fit_args,
+                suppress_warnings=suppress_warnings,
+                trace=trace, error_action=error_action,
+                out_of_sample_size=out_of_sample_size,
+                scoring=scoring, scoring_args=scoring_args,
+                with_intercept=with_intercept,
+                **sarimax_kwargs)
             for order, seasonal_order in gen)
 
     # otherwise, we're fitting the stepwise algorithm...
@@ -543,7 +545,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         Q = start_Q = min(start_Q, max_Q)
 
         # init the stepwise model wrapper
-        stepwise_wrapper = _StepwiseFitWrapper(
+        stepwise_wrapper = solvers._StepwiseFitWrapper(
             y, xreg=exogenous, start_params=start_params, trend=trend,
             method=method, transparams=transparams, solver=solver,
             maxiter=maxiter, disp=disp, callback=callback, fit_params=fit_args,

--- a/pmdarima/arima/seasonality.py
+++ b/pmdarima/arima/seasonality.py
@@ -286,7 +286,10 @@ class OCSBTest(_SeasonalStationarityTest):
     _ic_method_map = {
         "aic": lambda fit: fit.aic,
         "bic": lambda fit: fit.bic,
-        "aicc": lambda fit: _aicc(fit, fit.nobs)
+
+        # TODO: confirm False for add_constant, since the model fit contains
+        #   . a constant term
+        "aicc": lambda fit: _aicc(fit, fit.nobs, False)
     }
 
     def __init__(self, m, lag_method="aic", max_lag=3):

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-
-from pmdarima.arima import ARIMA, auto_arima, AutoARIMA, StepwiseContext
+from pmdarima.arima import ARIMA, auto_arima, AutoARIMA
 from pmdarima.arima.arima import VALID_SCORING, _uses_legacy_pickling
 from pmdarima.arima._auto_solvers import _fmt_warning_str
 from pmdarima.arima.auto import _post_ppc_arima
@@ -78,7 +76,11 @@ def test_basic_arma():
     assert arma.oob_preds_ is None
 
     # test some of the attrs
-    assert_almost_equal(arma.aic(), 11.201308403566909, decimal=5)
+    assert_almost_equal(arma.aic(), 11.201, decimal=3)  # equivalent in R
+
+    # intercept is param 0
+    intercept = arma.params()[0]
+    assert_almost_equal(intercept, 0.441, decimal=3)  # equivalent in R
     assert_almost_equal(arma.aicc(), 11.74676, decimal=5)
     assert_almost_equal(arma.bic(), 13.639060053303311, decimal=5)
 
@@ -414,8 +416,8 @@ def test_the_r_src():
     # this is the test the R code provides
     fit = ARIMA(order=(2, 0, 1), trend='c', suppress_warnings=True).fit(abc)
 
-    # the R code's AIC = ~135
-    assert abs(135 - fit.aic()) < 1.0
+    # the R code's AIC = 135.4
+    assert abs(135.4 - fit.aic()) < 1.0
 
     # the R code's AICc = ~ 137
     assert abs(137 - fit.aicc()) < 1.0
@@ -871,6 +873,7 @@ def test_to_dict_raises_attribute_error_on_unfit_model():
         modl.to_dict()
 
 
+# tgsmith61591: I really hate this test. But it ensures no drift, at least..
 def test_to_dict_is_accurate():
     train = lynx[:90]
     modl = auto_arima(train, start_p=1, start_q=1, start_P=1, start_Q=1,
@@ -908,7 +911,7 @@ def test_to_dict_is_accurate():
         'seasonal_order': (0, 0, 0, 1),
         'oob': np.nan,
         'aic': 1487.8850037609368,
-        'aicc': 1488.5992894752226,
+        'aicc': 1488.3555919962284,
         'bic': 1497.8842424422578,
         'bse': np.array([2.26237893e+02, 6.97744631e-02,
                          9.58556537e-02, 1.03225425e+05]),

--- a/pmdarima/arima/tests/test_context.py
+++ b/pmdarima/arima/tests/test_context.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+from pmdarima.arima.auto import StepwiseContext, auto_arima
+from pmdarima.arima._context import ContextStore, ContextType
+from pmdarima.datasets import load_lynx, load_wineind
+import pytest
+
+lynx = load_lynx()
+wineind = load_wineind()
+
+
+# test StepwiseContext parameter validation
+@pytest.mark.parametrize(
+    'max_steps,max_dur', [
+        pytest.param(-1, None),
+        pytest.param(0, None),
+        pytest.param(1001, None),
+        pytest.param(1100, None),
+        pytest.param(None, -1),
+        pytest.param(None, 0),
+    ])
+def test_stepwise_context_args(max_steps, max_dur):
+    with pytest.raises(ValueError):
+        StepwiseContext(max_steps=max_steps, max_dur=max_dur)
+
+
+# test auto_arima stepwise run with  StepwiseContext
+def test_auto_arima_with_stepwise_context():
+    samp = lynx[:8]
+    with StepwiseContext(max_steps=5, max_dur=30):
+        with pytest.warns(UserWarning) as uw:
+            auto_arima(samp, suppress_warnings=False, stepwise=True,
+                       error_action='ignore')
+
+            # assert that max_steps were taken
+            assert any(str(w.message)
+                       .startswith('stepwise search has reached the '
+                                   'maximum number of tries') for w in uw)
+
+
+# test effective context info in nested context scenario
+def test_nested_context():
+    ctx1_data = {'max_dur': 30}
+    ctx2_data = {'max_steps': 5}
+    ctx1 = StepwiseContext(**ctx1_data)
+    ctx2 = StepwiseContext(**ctx2_data)
+
+    with ctx1, ctx2:
+        effective_ctx_data = ContextStore.get_or_empty(
+            ContextType.STEPWISE)
+        expected_ctx_data = ctx1_data.copy()
+        expected_ctx_data.update(ctx2_data)
+
+        assert all(effective_ctx_data[key] == expected_ctx_data[key]
+                   for key in expected_ctx_data.keys())
+
+        assert all(effective_ctx_data[key] == expected_ctx_data[key]
+                   for key in effective_ctx_data.keys())
+
+
+# Test a context honors the max duration
+def test_max_dur():
+    # set arbitrarily low to guarantee will always pass after one iter
+    with StepwiseContext(max_dur=.5), \
+            pytest.warns(UserWarning) as uw:
+
+        auto_arima(lynx, stepwise=True)
+        # assert that max_dur was reached
+        assert any(str(w.message)
+                   .startswith('early termination') for w in uw)
+
+
+# Test that a context after the first will not inherit the first's attrs
+def test_subsequent_contexts():
+    # Force a very fast fit
+    with StepwiseContext(max_dur=.5), \
+            pytest.warns(UserWarning):
+        auto_arima(lynx, stepwise=True)
+
+    # Out of scope, should be EMPTY
+    assert ContextStore.get_or_empty(ContextType.STEPWISE).get_type() \
+           is ContextType.EMPTY
+
+    # Now show that we DON'T hit early termination by time here
+    with StepwiseContext(max_steps=100), \
+            pytest.warns(UserWarning) as uw:
+
+        ctx = ContextStore.get_or_empty(ContextType.STEPWISE)
+        assert ctx.get_type() is ContextType.STEPWISE
+        assert ctx.max_dur is None
+
+        auto_arima(lynx, stepwise=True)
+        # assert that max_dur was NOT reached
+        assert not any(str(w.message)
+                       .startswith('early termination') for w in uw)
+
+
+# test param validation of ContextStore's add, get and remove members
+def test_add_get_remove_context_args():
+    with pytest.raises(ValueError):
+        ContextStore._add_context(None)
+
+    with pytest.raises(ValueError):
+        ContextStore._remove_context(None)
+
+    with pytest.raises(ValueError):
+        ContextStore.get_context(None)

--- a/pmdarima/arima/tests/test_context.py
+++ b/pmdarima/arima/tests/test_context.py
@@ -79,7 +79,7 @@ def test_subsequent_contexts():
 
     # Out of scope, should be EMPTY
     assert ContextStore.get_or_empty(ContextType.STEPWISE).get_type() \
-           is ContextType.EMPTY
+        is ContextType.EMPTY
 
     # Now show that we DON'T hit early termination by time here
     with StepwiseContext(max_steps=100), \

--- a/pmdarima/compat/statsmodels.py
+++ b/pmdarima/compat/statsmodels.py
@@ -8,9 +8,6 @@ __all__ = [
     'bind_df_model'
 ]
 
-DEFAULT_NON_SEASONAL_MAXITER = 500  # ARMA, ARIMA
-DEFAULT_SEASONAL_MAXITER = 50  # SARIMAX
-
 
 def bind_df_model(model_fit, arima_results):
     """Set model degrees of freedom.

--- a/pmdarima/utils/wrapped.py
+++ b/pmdarima/utils/wrapped.py
@@ -15,6 +15,8 @@ __all__ = [
     'pacf'
 ]
 
+# TODO: remove all explicit args/kwargs, making them *args, **kwargs
+
 
 def inheritdoc(parent):
     """Inherit documentation from a parent


### PR DESCRIPTION
# Description

This fixes #211 by updating our `ARIMA` class to only use the statsmodels SARIMAX under the hood, per the thread here: https://github.com/statsmodels/statsmodels/issues/6225#issuecomment-550350284

It should not cause any breaking changes, though it will yield very slightly different results for some parameter combinations. It also will yield two new warnings for explicitly setting the old default values to some hyper-parameters.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (**only in the sense that existing models may yield very slight differences in parameters**)
- [x] Documentation change

# How Has This Been Tested?

All existing tests pass (with minor updates where required), and parity with R package functionality is the same as before.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes