### PR TITLE
[MRG+1] Add support for meaningful exog names 

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -247,6 +247,8 @@ Array helper functions & metaestimators
     utils.acf
     utils.as_series
     utils.c
+    utils.check_endog
+    utils.check_exog
     utils.diff
     utils.if_has_delegate
     utils.is_iterable

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,12 @@ v0.8.1) will document the latest features.
 * New :class:`pmdarima.arima.auto.StepwiseContext` feature for more control over
   fit duration (introduced by `@kpsunkara <https://github.com/kpsunkara>`_ in `#221 <https://github.com/tgsmith61591/pmdarima/pull/221>`_).
 
+* Exogenous arrays are no longer cast to numpy array by default, and will pass pandas
+  frames through to the model. This keeps variable names intact in the summary
+
+* Added the ``prefix`` param to exogenous featurizers to allow the addition of meaningful
+  names to engineered features.
+
 
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_
 --------------------------------------------------

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -88,7 +88,8 @@ def _seasonal_prediction_with_confidence(arima_res, start, end, exog, alpha,
 
     f = results.predicted_mean
     conf_int = results.conf_int(alpha=alpha)
-    return f, conf_int
+    return check_endog(f, dtype=None, copy=False), \
+        check_array(conf_int, copy=False, dtype=None)
 
 
 def _uses_legacy_pickling(arima):
@@ -282,7 +283,7 @@ class ARIMA(BaseARIMA):
     """
     def __init__(self, order, seasonal_order=(0, 0, 0, 0), start_params=None,
                  method='lbfgs', transparams=True, solver='lbfgs',
-                 maxiter=None, disp=0, callback=None, suppress_warnings=False,
+                 maxiter=50, disp=0, callback=None, suppress_warnings=False,
                  out_of_sample_size=0, scoring='mse', scoring_args=None,
                  trend=None, with_intercept=True, **sarimax_kwargs):
 

--- a/pmdarima/arima/arima.py
+++ b/pmdarima/arima/arima.py
@@ -23,7 +23,8 @@ from ..base import BaseARIMA
 from ..compat.numpy import DTYPE  # DTYPE for arrays
 from ..compat.python import long
 from ..compat import statsmodels as sm_compat
-from ..utils import get_callable, if_has_delegate, is_iterable, check_endog
+from ..utils import get_callable, if_has_delegate, is_iterable, check_endog, \
+    check_exog
 from ..utils.visualization import _get_plt
 
 # Get the version
@@ -412,9 +413,8 @@ class ARIMA(BaseARIMA):
 
         # if exog was included, check the array...
         if exogenous is not None:
-            exogenous = check_array(exogenous, ensure_2d=True,
-                                    force_all_finite=False,
-                                    copy=False, dtype=DTYPE)
+            exogenous = check_exog(exogenous, force_all_finite=False,
+                                   copy=False, dtype=DTYPE)
 
         # determine the CV args, if any
         cv = self.out_of_sample_size
@@ -472,8 +472,8 @@ class ARIMA(BaseARIMA):
                                  'array, it must also be provided one for '
                                  'predicting or updating observations.')
             else:
-                return check_array(exogenous, ensure_2d=True,
-                                   force_all_finite=True, dtype=DTYPE)
+                return check_exog(
+                    exogenous, force_all_finite=True, dtype=DTYPE)
         return None
 
     def predict_in_sample(self, exogenous=None, start=None,

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -170,6 +170,11 @@ class AutoARIMA(BaseARIMA):
         return self.model_.update(
             y, exogenous=exogenous, maxiter=maxiter, **kwargs)
 
+    @if_has_delegate('model_')
+    def summary(self):
+        """Get a summary of the ARIMA model"""
+        return self.model_.summary()
+
     # TODO: decorator to automate all this composition + AIC, etc.
 
 

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -5,6 +5,7 @@ import warnings
 
 from sklearn.base import BaseEstimator, clone
 from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.metaestimators import if_delegate_has_method
 
 from .base import BaseARIMA
 from .preprocessing.base import BaseTransformer
@@ -407,6 +408,11 @@ class Pipeline(BaseEstimator):
         if return_conf_int:
             return y_pred, conf_ints
         return y_pred
+
+    @if_delegate_has_method('_final_estimator')
+    def summary(self):
+        """Get a summary of the ARIMA model"""
+        return self._final_estimator.summary()
 
     def update(self, y, exogenous=None, maxiter=None, **kwargs):
         """Update an ARIMA or auto-ARIMA as well as any necessary transformers

--- a/pmdarima/preprocessing/base.py
+++ b/pmdarima/preprocessing/base.py
@@ -5,11 +5,10 @@
 
 from sklearn.base import BaseEstimator, TransformerMixin
 import six
-from sklearn.utils.validation import check_array, column_or_1d
-
 import abc
 
 from ..compat.numpy import DTYPE
+from ..utils import check_exog, check_endog
 
 __all__ = [
     "BaseTransformer"
@@ -37,12 +36,11 @@ class BaseTransformer(six.with_metaclass(abc.ABCMeta,
         """Validate input"""
         # Do not force finite, since a transformer's goal may be imputation.
         if y is not None:
-            y = column_or_1d(
-                check_array(y, ensure_2d=False, dtype=DTYPE, copy=True,
-                            force_all_finite=False))
+            y = check_endog(y, dtype=DTYPE, copy=True, force_all_finite=False)
+
         if exog is not None:
-            exog = check_array(exog, ensure_2d=True, dtype=DTYPE,
-                               copy=True, force_all_finite=False)
+            exog = check_exog(
+                exog, dtype=DTYPE, copy=True, force_all_finite=False)
         return y, exog
 
     def fit_transform(self, y, exogenous=None, **transform_kwargs):

--- a/pmdarima/preprocessing/exog/base.py
+++ b/pmdarima/preprocessing/exog/base.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import pandas as pd
+import numpy as np
 import six
-
 import abc
 
 from ..base import BaseTransformer
@@ -20,7 +21,39 @@ class BaseExogTransformer(six.with_metaclass(abc.ABCMeta, BaseTransformer)):
 
 
 class BaseExogFeaturizer(six.with_metaclass(abc.ABCMeta, BaseExogTransformer)):
-    """Exogenous transformers that create exog features from the endog array"""
+    """Exogenous transformers that create exog features from the endog array
+
+    Parameters
+    ----------
+    prefix : str or None, optional (default=None)
+        The feature prefix
+    """
+    def __init__(self, prefix=None):
+        self.prefix = prefix
+
+    @abc.abstractmethod
+    def _get_prefix(self):
+        """Get the feature prefix for when exog is a pd.DataFrame"""
+
+    def _safe_hstack(self, exog, features):
+        """H-stack dataframes or np.ndarrays"""
+        if exog is None or isinstance(exog, pd.DataFrame):
+            # this is set in the 'fit' method
+            pfx = self._get_prefix()
+
+            # the features we're adding may be np.ndarray
+            if not isinstance(features, pd.DataFrame):
+                features = pd.DataFrame.from_records(features)
+            # set the names
+            features.columns = [
+                '%s_%i' % (pfx, i) for i in range(features.shape[1])]
+
+            if exog is not None:
+                return pd.concat([exog, features], axis=1, ignore_index=True)
+            # if exog was None coming in, we'd still like to favor a pd.DF
+            return features
+
+        return np.hstack([exog, features])
 
     def transform(self, y, exogenous=None, n_periods=0, **kwargs):
         """Transform the new array

--- a/pmdarima/preprocessing/exog/fourier.py
+++ b/pmdarima/preprocessing/exog/fourier.py
@@ -66,28 +66,18 @@ class FourierFeaturizer(BaseExogFeaturizer, UpdatableMixin):
     Examples
     --------
     >>> import pandas as pd
-    >>> pd.options.display.max_columns = 6  # for display...
     >>> from pmdarima.preprocessing import FourierFeaturizer
     >>> from pmdarima.datasets import load_wineind
     >>> y = load_wineind()
     >>> trans = FourierFeaturizer(12, 4)
     >>> y_prime, exog = trans.fit_transform(y)
     >>> exog.head()
-       FOURIER_0     FOURIER_1    ...      \
-    0   0.500000  8.660254e-01    ...
-    1   0.866025  5.000000e-01    ...
-    2   1.000000 -4.371139e-08    ...
-    3   0.866025 -5.000001e-01    ...
-    4   0.500000 -8.660254e-01    ...
-
-          FOURIER_6  FOURIER_7
-    0  8.660254e-01       -0.5
-    1 -8.660255e-01       -0.5
-    2  1.748456e-07        1.0
-    3  8.660253e-01       -0.5
-    4 -8.660255e-01       -0.5
-
-    [5 rows x 8 columns]
+       FOURIER_0     FOURIER_1    ...     FOURIER_6  FOURIER_7
+    0   0.500000  8.660254e-01    ...  8.660254e-01       -0.5
+    1   0.866025  5.000000e-01    ... -8.660255e-01       -0.5
+    2   1.000000 -4.371139e-08    ...  1.748456e-07        1.0
+    3   0.866025 -5.000001e-01    ...  8.660253e-01       -0.5
+    4   0.500000 -8.660254e-01    ... -8.660255e-01       -0.5
 
     Notes
     -----

--- a/pmdarima/preprocessing/exog/tests/test_fourier.py
+++ b/pmdarima/preprocessing/exog/tests/test_fourier.py
@@ -66,6 +66,8 @@ class TestFourierREquivalency:
         _, xreg = trans.transform(y, exog)
 
         # maybe subset
+        if hasattr(xreg, 'iloc'):
+            xreg = xreg.values
         assert_array_almost_equal(expected, xreg[:, -4:])
 
         # maybe assert on exog

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -103,6 +103,9 @@ def test_get_kwargs(pipe, kwargs, expected):
     kw = pipe._get_kwargs(**kwargs)
     assert kw == expected
 
+    # show we can convert steps to dict
+    assert pipe.named_steps
+
 
 def test_pipeline_behavior():
     pipeline = Pipeline([

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -106,6 +106,9 @@ def test_get_kwargs(pipe, kwargs, expected):
     # show we can convert steps to dict
     assert pipe.named_steps
 
+    # show we can get a summary
+    pipe.summary()
+
 
 def test_pipeline_behavior():
     pipeline = Pipeline([

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -106,9 +106,6 @@ def test_get_kwargs(pipe, kwargs, expected):
     # show we can convert steps to dict
     assert pipe.named_steps
 
-    # show we can get a summary
-    pipe.summary()
-
 
 def test_pipeline_behavior():
     pipeline = Pipeline([
@@ -186,6 +183,9 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
     exog_train, exog_test = exog
 
     pipeline.fit(train, exogenous=exog_train)
+
+    # show we can get a summary
+    pipeline.summary()
 
     # first predict
     predictions = pipeline.predict(


### PR DESCRIPTION
# Description

Fixes #222. Adds an optional parameter, `prefix`, to exogenous featurizers and pass-through support for pandas DataFrames as exog arrays (rather than converting to np.ndarray). This accomplishes two things:

* If a pandas frame is provided as an exog array to the statsmodels SARIMAX class, it will keep the names intact and the `summary` method will contain the meaningful names
* Featurizer classes will name their generated features with the `prefix`, meaning the summary will contain their variable names as well.

The only case where no meaningful names will be retained is when a numpy array is fed into a featurizer (cannot concatenate numpy and pandas) or directly into a model. Here's an example:

```python
In [1]: from pmdarima.pipeline import Pipeline
   ...: from pmdarima.preprocessing import BoxCoxEndogTransformer, FourierFeaturizer
   ...: from pmdarima.arima import AutoARIMA
   ...: from pmdarima.datasets import load_wineind
   ...: import numpy as np
   ...:
   ...: wineind = load_wineind()
   ...: train, test = wineind[:125], wineind[125:]
In [2]: pipe = Pipeline([
   ...:         ("boxcox", BoxCoxEndogTransformer()),
   ...:         ("fourier", FourierFeaturizer(m=12)),
   ...:         ("arima", AutoARIMA(seasonal=False, stepwise=True,
   ...:                             suppress_warnings=True, d=1, max_p=2, max_q=0,
   ...:                             start_q=0, start_p=1,
   ...:                             maxiter=3, error_action='ignore'))
   ...:     ])
In [3]: pipe.fit(train)
Out[3]:
Pipeline(steps=[('boxcox',
                 BoxCoxEndogTransformer(floor=1e-16, lmbda=None, lmbda2=0,
                                        neg_action='raise')),
                ('fourier', FourierFeaturizer(k=None, m=12, prefix=None)),
                ('arima',
                 AutoARIMA(D=None, alpha=0.05, callback=None, d=1, disp=0,
                           error_action='ignore', information_criterion='aic',
                           m=1, max_D=1, max_P=2, max_Q=2, max_d=2,
                           max_order=10, max_p=2, max_q=0, maxiter=3,
                           method='lbfgs', n_fits=10, n_jobs=1,
                           offset_test_args=None, out_of_sample_size=0,
                           random=False, random_state=None, sarimax_kwargs=None,
                           scoring='mse', scoring_args=None, seasonal=False,
                           seasonal_test='ocsb', seasonal_test_args=None,
                           solver='lbfgs', ...))])
In [4]: pipe.summary()
Out[4]:
<class 'statsmodels.iolib.summary.Summary'>
"""
                           Statespace Model Results
==============================================================================
Dep. Variable:                      y   No. Observations:                  125
Model:               SARIMAX(2, 1, 0)   Log Likelihood                  49.601
Date:                Tue, 19 Nov 2019   AIC                            -67.202
Time:                        08:02:39   BIC                            -22.078
Sample:                             0   HQIC                           -48.872
                                - 125
Covariance Type:                  opg
==============================================================================
                 coef    std err          z      P>|z|      [0.025      0.975]
------------------------------------------------------------------------------
intercept      0.0091      0.018      0.502      0.615      -0.026       0.044
FOURIER_0     -0.2289      0.024     -9.733      0.000      -0.275      -0.183
FOURIER_1      0.0247      0.023      1.075      0.282      -0.020       0.070
FOURIER_2     -0.1101      0.015     -7.209      0.000      -0.140      -0.080
FOURIER_3      0.1123      0.017      6.477      0.000       0.078       0.146
FOURIER_4     -0.2197      0.019    -11.530      0.000      -0.257      -0.182
FOURIER_5      0.2164      0.022     10.058      0.000       0.174       0.259
FOURIER_6     -0.0758      0.031     -2.424      0.015      -0.137      -0.015
FOURIER_7      0.0760      0.039      1.937      0.053      -0.001       0.153
FOURIER_8     -0.0060      0.020     -0.303      0.762      -0.045       0.033
FOURIER_9      0.1306      0.022      5.821      0.000       0.087       0.175
FOURIER_10  1739.6486   3461.000      0.503      0.615   -5043.786    8523.084
FOURIER_11     0.0467      0.026      1.808      0.071      -0.004       0.097
ar.L1         -0.7449      0.081     -9.235      0.000      -0.903      -0.587
ar.L2         -0.5253      0.089     -5.935      0.000      -0.699      -0.352
sigma2         0.0262      0.003      7.868      0.000       0.020       0.033
===================================================================================
Ljung-Box (Q):                       67.43   Jarque-Bera (JB):                30.98
Prob(Q):                              0.00   Prob(JB):                         0.00
Heteroskedasticity (H):               3.94   Skew:                             0.22
Prob(H) (two-sided):                  0.00   Kurtosis:                         5.41
===================================================================================

Warnings:
[1] Covariance matrix calculated using the outer product of gradients (complex-step).
"""
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change

# How Has This Been Tested?

Multiple new unit tests, and existing unit tests pass

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes