### PR TITLE
[MRG+1] Back out deprecated constructor args

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -42,7 +42,15 @@ v0.8.1) will document the latest features.
   as requested in `#208 <https://github.com/tgsmith61591/pmdarima/issues/208>`_.
 
 * Removes ``pmdarima.arima.ARIMA.add_new_samples``, which was previously deprecated.
-  Use ``pmdarima.arima.ARIMA.update`` instead.
+  Use :func:`pmdarima.arima.ARIMA.update` instead.
+
+* The following args have been deprecated:
+
+  - ``disp``
+  - ``callback``
+
+  They can still be passed to the ``fit`` method via ``**fit_kwargs``, but should
+  no longer be passed to the model constructor.
 
 
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -59,7 +59,7 @@ class _StepwiseFitWrapper:
     .. [2] https://robjhyndman.com/hyndsight/arma-roots/
     """
     def __init__(self, y, xreg, start_params, trend, method, transparams,
-                 solver, maxiter, disp, callback, fit_params,
+                 solver, maxiter, fit_params,
                  suppress_warnings, trace, error_action, out_of_sample_size,
                  scoring, scoring_args, p, d, q, P, D, Q, m, start_p, start_q,
                  start_P, start_Q, max_p, max_q, max_P, max_Q, seasonal,
@@ -68,12 +68,20 @@ class _StepwiseFitWrapper:
         # Create a partial of the fit call so we don't have arg bloat all over
         self._fit_arima = functools.partial(
             _fit_arima,
-            x=y, xreg=xreg, start_params=start_params, trend=trend,
-            method=method, transparams=transparams, solver=solver,
-            maxiter=maxiter, disp=disp, callback=callback,
-            fit_params=fit_params, suppress_warnings=suppress_warnings,
-            trace=trace, error_action=error_action,
-            out_of_sample_size=out_of_sample_size, scoring=scoring,
+            x=y,
+            xreg=xreg,
+            start_params=start_params,
+            trend=trend,
+            method=method,
+            transparams=transparams,
+            solver=solver,
+            maxiter=maxiter,
+            fit_params=fit_params,
+            suppress_warnings=suppress_warnings,
+            trace=trace,
+            error_action=error_action,
+            out_of_sample_size=out_of_sample_size,
+            scoring=scoring,
             scoring_args=scoring_args,
             information_criterion=information_criterion,
             **kwargs)
@@ -332,7 +340,7 @@ class _StepwiseFitWrapper:
 
 
 def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
-               method, transparams, solver, maxiter, disp, callback,
+               method, transparams, solver, maxiter,
                fit_params, suppress_warnings, trace, error_action,
                out_of_sample_size, scoring, scoring_args, with_intercept,
                **kwargs):
@@ -341,7 +349,6 @@ def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
         fit = ARIMA(order=order, seasonal_order=seasonal_order,
                     start_params=start_params, trend=trend, method=method,
                     transparams=transparams, solver=solver, maxiter=maxiter,
-                    disp=disp, callback=callback,
                     suppress_warnings=suppress_warnings,
                     out_of_sample_size=out_of_sample_size, scoring=scoring,
                     scoring_args=scoring_args,

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -171,15 +171,6 @@ _AUTO_ARIMA_DOCSTR = \
     maxiter : int, optional (default=50)
         The maximum number of function evaluations. Default is 50.
 
-    disp : int, optional (default=0)
-        If True, convergence information is printed.  For the default
-        'lbfgs' ``solver``, disp controls the frequency of the output during
-        the iterations. disp < 0 means no output in this case.
-
-    callback : callable, optional (default=None)
-        Called after each iteration as callback(xk) where xk is the current
-        parameter vector. This is only used in non-seasonal ARIMA models.
-
     offset_test_args : dict, optional (default=None)
         The args to pass to the constructor of the offset (``d``) test. See
         ``pmdarima.arima.stationarity`` for more details.
@@ -250,8 +241,7 @@ _AUTO_ARIMA_DOCSTR = \
     with_intercept : bool, optional (default=True)
         Whether to include an intercept term. Default is True.
     
-    sarimax_kwargs : dict or None, optional (default=None)
-        Keyword arguments to pass to the SARIMAX constructor, if seasonal.
+    {sarimax_kwargs}
     {fit_args}
     See Also
     --------
@@ -285,6 +275,16 @@ _EXOG_DOCSTR = """
         operation. This should not include a constant or trend. Note that
         if an ``ARIMA`` is fit on exogenous features, it must be provided
         exogenous features for making predictions.
+"""
+
+_KWARGS_DOCSTR = """
+    **kwargs : dict or None, optional (default=None)
+        Keyword arguments to pass to the ARIMA constructor.
+"""
+
+_SARIMAX_ARGS_DOCSTR = """
+    sarimax_kwargs : dict or None, optional (default=None)
+        Keyword arguments to pass to the ARIMA constructor.
 """
 
 _FIT_ARGS_DOCSTR = """

--- a/pmdarima/preprocessing/exog/tests/test_fourier.py
+++ b/pmdarima/preprocessing/exog/tests/test_fourier.py
@@ -91,7 +91,10 @@ def test_hyndman_blog():
     _, xreg = trans.transform(y)
 
     arima = pm.auto_arima(y, exogenous=xreg, seasonal=False,
-                          maxiter=5)  # type: pm.ARIMA
+                          maxiter=5,
+                          start_p=4, max_p=5,
+                          d=0, max_q=1, start_q=0,
+                          simple_differencing=True)  # type: pm.ARIMA
 
     # Show we can forecast 10 in the future
     _, xreg_test = trans.transform(y, n_periods=10)


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

Since the move to SARIMAX only, we have some deprecated constructor args we can back out. For now, there are warnings if they're found in kwargs. After a few versions we can completely remove the checks

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change

# How Has This Been Tested?

All existing tests pass.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
