### PR TITLE
[MRG+1] Deprecate more args

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,20 +10,15 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        against: parent
+        target: auto
         branches:
           - master
 
     patch:
       default:
-        # Be tolerant on slight code coverage diff on PRs to limit
-        # noisy red coverage status on github PRs.
-        # Note The coverage stats are still uploaded
-        # to codecov so that PR reviewers can see uncovered lines
-        # in the github diff if they install the codecov browser
-        # extension:
-        # https://github.com/codecov/browser-extension
-        target: 95%
+        against: parent
+        target: 80%
 
 ignore:
 - "**/setup.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,10 +10,7 @@ coverage:
   status:
     project:
       default:
-        # Commits pushed to master should not make the overall
-        # project coverage decrease by more than 1%:
-        target: auto
-        threshold: 1%
+        target: 95%
         branches:
           - master
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,10 +46,12 @@ v0.8.1) will document the latest features.
 
 * The following args have been deprecated:
 
-  - ``disp``
-  - ``callback``
+  - ``disp``:sup:[1]
+  - ``callback``:sup:[1]
+  - ``transparams``
+  - ``solver``
 
-  They can still be passed to the ``fit`` method via ``**fit_kwargs``, but should
+  [1] These can still be passed to the ``fit`` method via ``**fit_kwargs``, but should
   no longer be passed to the model constructor.
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -44,12 +44,14 @@ v0.8.1) will document the latest features.
 * Removes ``pmdarima.arima.ARIMA.add_new_samples``, which was previously deprecated.
   Use :func:`pmdarima.arima.ARIMA.update` instead.
 
-* The following args have been deprecated:
+* The following args have been deprecated from the :class:`pmdarima.arima.ARIMA` class
+  as well as :func:`pmdarima.arima.auto_arima` and any other calling methods/classes:
 
-  - ``disp``:sup:[1]
-  - ``callback``:sup:[1]
+  - ``disp``:sup:`[1]`
+  - ``callback``:sup:`[1]`
   - ``transparams``
   - ``solver``
+  - ``typ``
 
   [1] These can still be passed to the ``fit`` method via ``**fit_kwargs``, but should
   no longer be passed to the model constructor.

--- a/examples/example_pipeline.py
+++ b/examples/example_pipeline.py
@@ -40,7 +40,6 @@ pipe = pipeline.Pipeline([
     ("fourier", ppc.FourierFeaturizer(m=12, k=4)),
     ("arima", arima.AutoARIMA(stepwise=True, trace=1, error_action="ignore",
                               seasonal=False,  # because we use Fourier
-                              transparams=False,
                               suppress_warnings=True))
 ])
 

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -35,7 +35,7 @@ def _root_test(model, ic, trace):
     if max_invroot > 1 - 1e-2:
         ic = np.inf
         if trace:
-            warnings.warn(
+            print(
                 "Near non-invertible roots for order "
                 "(%i, %i, %i)(%i, %i, %i, %i); setting score to inf (at "
                 "least one inverse root too close to the border of the "

--- a/pmdarima/arima/_auto_solvers.py
+++ b/pmdarima/arima/_auto_solvers.py
@@ -58,10 +58,10 @@ class _StepwiseFitWrapper:
     .. [1] R's auto-arima stepwise source code: http://bit.ly/2vOma0W
     .. [2] https://robjhyndman.com/hyndsight/arma-roots/
     """
-    def __init__(self, y, xreg, start_params, trend, method, transparams,
-                 solver, maxiter, fit_params,
-                 suppress_warnings, trace, error_action, out_of_sample_size,
-                 scoring, scoring_args, p, d, q, P, D, Q, m, start_p, start_q,
+    def __init__(self, y, xreg, start_params, trend, method, maxiter,
+                 fit_params, suppress_warnings, trace, error_action,
+                 out_of_sample_size, scoring, scoring_args,
+                 p, d, q, P, D, Q, m, start_p, start_q,
                  start_P, start_Q, max_p, max_q, max_P, max_Q, seasonal,
                  information_criterion, with_intercept, **kwargs):
 
@@ -73,8 +73,6 @@ class _StepwiseFitWrapper:
             start_params=start_params,
             trend=trend,
             method=method,
-            transparams=transparams,
-            solver=solver,
             maxiter=maxiter,
             fit_params=fit_params,
             suppress_warnings=suppress_warnings,
@@ -340,16 +338,15 @@ class _StepwiseFitWrapper:
 
 
 def _fit_arima(x, xreg, order, seasonal_order, start_params, trend,
-               method, transparams, solver, maxiter,
-               fit_params, suppress_warnings, trace, error_action,
-               out_of_sample_size, scoring, scoring_args, with_intercept,
-               **kwargs):
+               method, maxiter, fit_params, suppress_warnings,
+               trace, error_action,
+               out_of_sample_size, scoring, scoring_args,
+               with_intercept, **kwargs):
     start = time.time()
     try:
         fit = ARIMA(order=order, seasonal_order=seasonal_order,
                     start_params=start_params, trend=trend, method=method,
-                    transparams=transparams, solver=solver, maxiter=maxiter,
-                    suppress_warnings=suppress_warnings,
+                    maxiter=maxiter, suppress_warnings=suppress_warnings,
                     out_of_sample_size=out_of_sample_size, scoring=scoring,
                     scoring_args=scoring_args,
                     with_intercept=with_intercept, **kwargs)\

--- a/pmdarima/arima/_doc.py
+++ b/pmdarima/arima/_doc.py
@@ -143,11 +143,6 @@ _AUTO_ARIMA_DOCSTR = \
         Starting parameters for ``ARMA(p,q)``.  If None, the default is given
         by ``ARMA._fit_start_params``.
 
-    transparams : bool, optional (default=True)
-        Whether or not to transform the parameters to ensure stationarity.
-        Uses the transformation suggested in Jones (1980).  If False,
-        no checking for stationarity or invertibility is done.
-
     method : str, optional (default='lbfgs')
         One of ('newton', 'bfgs', 'lbfgs', 'powell', 'cg', 'ncg',
         'basinhopping'). Determines a solver method for maximizing the
@@ -158,15 +153,6 @@ _AUTO_ARIMA_DOCSTR = \
         The trend parameter. If ``with_intercept`` is True, ``trend`` will be
         used. If ``with_intercept`` is False, the trend will be set to a no-
         intercept value.
-
-    solver : str or None, optional (default='lbfgs')
-        Solver to be used.  The default is 'lbfgs' (limited memory
-        Broyden-Fletcher-Goldfarb-Shanno).  Other choices are 'bfgs',
-        'newton' (Newton-Raphson), 'nm' (Nelder-Mead), 'cg' -
-        (conjugate gradient), 'ncg' (non-conjugate gradient), and
-        'powell'. By default, the limited memory BFGS uses m=12 to
-        approximate the Hessian, projected gradient tolerance of 1e-8 and
-        factr = 1e2. You can change these by using kwargs.
 
     maxiter : int, optional (default=50)
         The maximum number of function evaluations. Default is 50.

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -39,7 +39,8 @@ def _warn_for_deprecations(**kwargs):
     for k in ('solver', 'transparams'):
         if kwargs.pop(k, None):
             warnings.warn('%s has been deprecated and will be removed in '
-                          'a future version.' % k)
+                          'a future version.' % k,
+                          DeprecationWarning)
     return kwargs
 
 

--- a/pmdarima/arima/auto.py
+++ b/pmdarima/arima/auto.py
@@ -34,6 +34,15 @@ __all__ = [
 VALID_CRITERIA = {'aic', 'aicc', 'bic', 'hqic', 'oob'}
 
 
+def _warn_for_deprecations(**kwargs):
+    # TODO: remove these warnings in the future
+    for k in ('solver', 'transparams'):
+        if kwargs.pop(k, None):
+            warnings.warn('%s has been deprecated and will be removed in '
+                          'a future version.' % k)
+    return kwargs
+
+
 class AutoARIMA(BaseARIMA):
     # Don't add the y, exog, etc. here since they are used in 'fit'
     __doc__ = _doc._AUTO_ARIMA_DOCSTR.format(
@@ -49,8 +58,7 @@ class AutoARIMA(BaseARIMA):
                  max_D=1, max_Q=2, max_order=5, m=1, seasonal=True,
                  stationary=False, information_criterion='aic', alpha=0.05,
                  test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
-                 start_params=None, trend=None, method='lbfgs',
-                 transparams=True, solver='lbfgs', maxiter=50,
+                 start_params=None, trend=None, method='lbfgs', maxiter=50,
                  offset_test_args=None, seasonal_test_args=None,
                  suppress_warnings=False, error_action='warn', trace=False,
                  random=False, random_state=None, n_fits=10,
@@ -83,8 +91,6 @@ class AutoARIMA(BaseARIMA):
         self.start_params = start_params
         self.trend = trend
         self.method = method
-        self.transparams = transparams
-        self.solver = solver
         self.maxiter = maxiter
         self.offset_test_args = offset_test_args
         self.seasonal_test_args = seasonal_test_args
@@ -108,6 +114,7 @@ class AutoARIMA(BaseARIMA):
                           "This will raise in future versions",
                           DeprecationWarning)
 
+        kwargs = _warn_for_deprecations(**kwargs)
         self.kwargs = kwargs
 
     def fit(self, y, exogenous=None, **fit_args):
@@ -147,8 +154,7 @@ class AutoARIMA(BaseARIMA):
             alpha=self.alpha, test=self.test, seasonal_test=self.seasonal_test,
             stepwise=self.stepwise, n_jobs=self.n_jobs,
             start_params=self.start_params, trend=self.trend,
-            method=self.method, transparams=self.transparams,
-            solver=self.solver, maxiter=self.maxiter,
+            method=self.method, maxiter=self.maxiter,
             offset_test_args=self.offset_test_args,
             seasonal_test_args=self.seasonal_test_args,
             suppress_warnings=self.suppress_warnings,
@@ -252,8 +258,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                max_D=1, max_Q=2, max_order=5, m=1, seasonal=True,
                stationary=False, information_criterion='aic', alpha=0.05,
                test='kpss', seasonal_test='ocsb', stepwise=True, n_jobs=1,
-               start_params=None, trend=None, method='lbfgs', transparams=True,
-               solver='lbfgs', maxiter=50,
+               start_params=None, trend=None, method='lbfgs', maxiter=50,
                offset_test_args=None, seasonal_test_args=None,
                suppress_warnings=False, error_action='warn', trace=False,
                random=False, random_state=None, n_fits=10,
@@ -262,6 +267,9 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                sarimax_kwargs=None, **fit_args):
 
     # NOTE: Doc is assigned BELOW this function
+
+    # pop out the deprecated kwargs
+    fit_args = _warn_for_deprecations(**fit_args)
 
     start = time.time()
 
@@ -324,8 +332,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                 y, xreg=exogenous, order=(0, 0, 0),
                 seasonal_order=(0, 0, 0, 0),
                 start_params=start_params, trend=trend, method=method,
-                transparams=transparams, solver=solver, maxiter=maxiter,
-                fit_params=fit_args,
+                maxiter=maxiter, fit_params=fit_args,
                 suppress_warnings=suppress_warnings, trace=trace,
                 error_action=error_action, scoring=scoring,
                 out_of_sample_size=out_of_sample_size,
@@ -464,8 +471,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                     y, xreg=exogenous, order=(0, d, 0),
                     seasonal_order=ssn,
                     start_params=start_params, trend=trend,
-                    method=method, transparams=transparams,
-                    solver=solver, maxiter=maxiter,
+                    method=method, maxiter=maxiter,
                     fit_params=fit_args,
                     suppress_warnings=suppress_warnings,
                     trace=trace,
@@ -538,8 +544,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
                 y, xreg=exogenous, order=order,
                 seasonal_order=seasonal_order,
                 start_params=start_params, trend=trend,
-                method=method, transparams=transparams,
-                solver=solver, maxiter=maxiter,
+                method=method, maxiter=maxiter,
                 fit_params=fit_args,
                 suppress_warnings=suppress_warnings,
                 trace=trace, error_action=error_action,
@@ -565,8 +570,7 @@ def auto_arima(y, exogenous=None, start_p=2, d=None, start_q=2, max_p=5,
         # init the stepwise model wrapper
         stepwise_wrapper = solvers._StepwiseFitWrapper(
             y, xreg=exogenous, start_params=start_params, trend=trend,
-            method=method, transparams=transparams, solver=solver,
-            maxiter=maxiter, fit_params=fit_args,
+            method=method, maxiter=maxiter, fit_params=fit_args,
             suppress_warnings=suppress_warnings, trace=trace,
             error_action=error_action, out_of_sample_size=out_of_sample_size,
             scoring=scoring, scoring_args=scoring_args, p=p, d=d, q=q,

--- a/pmdarima/arima/tests/test_arima.py
+++ b/pmdarima/arima/tests/test_arima.py
@@ -533,6 +533,7 @@ def test_with_seasonality2():
                               'simple_differencing': simple_differencing},
 
                           # Set to super low iter to make test move quickly
+                          max_order=None,
                           maxiter=2)
 
     # show that we can forecast even after the

--- a/pmdarima/arima/tests/test_auto.py
+++ b/pmdarima/arima/tests/test_auto.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from pmdarima.arima import auto
+import pytest
+
+
+def test_deprecation_warnings():
+    kwargs = {'transparams': True, 'method': 'lbfgs'}
+    with pytest.warns(DeprecationWarning) as we:
+        kwargs = auto._warn_for_deprecations(**kwargs)
+    assert kwargs['method']
+    assert 'transparams' not in kwargs
+    assert we
+
+
+def test_deprecation_warnings_on_class():
+    with pytest.warns(DeprecationWarning) as we:
+        auto.AutoARIMA(sarimax_kwargs={"simple_differencing": True})
+    assert we

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -22,7 +22,8 @@ def _warn_for_deprecated(**kwargs):
     for k in ('typ',):
         if kwargs.pop(k, None):
             warnings.warn("'%s' is deprecated and will be removed in a future "
-                          "release" % k)
+                          "release" % k,
+                          DeprecationWarning)
     return kwargs
 
 

--- a/pmdarima/pipeline.py
+++ b/pmdarima/pipeline.py
@@ -17,6 +17,15 @@ from .compat import DTYPE
 __all__ = ['Pipeline']
 
 
+def _warn_for_deprecated(**kwargs):
+    # TODO: remove this in the future
+    for k in ('typ',):
+        if kwargs.pop(k, None):
+            warnings.warn("'%s' is deprecated and will be removed in a future "
+                          "release" % k)
+    return kwargs
+
+
 class Pipeline(BaseEstimator):
     """A pipeline of transformers with an optional final estimator stage
 
@@ -232,7 +241,7 @@ class Pipeline(BaseEstimator):
 
     def predict_in_sample(self, exogenous=None, start=None,
                           end=None, dynamic=False, return_conf_int=False,
-                          alpha=0.05, typ='levels', inverse_transform=True,
+                          alpha=0.05, inverse_transform=True,
                           **kwargs):
         """Generate in-sample predictions from the fit pipeline.
 
@@ -271,16 +280,6 @@ class Pipeline(BaseEstimator):
         alpha : float, optional (default=0.05)
             The confidence intervals for the forecasts are (1 - alpha) %
 
-        typ : str, optional (default='levels')
-            The type of prediction to make. Options are ('linear', 'levels').
-            This is only used when the underlying model is ARIMA (not ARMA or
-            SARIMAX).
-
-              - 'linear': makes linear predictions in terms of the differenced
-                endogenous variables.
-              - 'levels': predicts the levels of the original endogenous
-                variables.
-
         inverse_transform : bool, optional (default=True)
             Whether to inverse transform predictions, if they are in log or
             BoxCox scale. Any endog transformer will be inverse-transformed.
@@ -304,12 +303,13 @@ class Pipeline(BaseEstimator):
             The confidence intervals for the predictions. Only returned if
             ``return_conf_int`` is True.
         """
+        kwargs = _warn_for_deprecated(**kwargs)
         Xt, est, predict_kwargs = self._pre_predict(0, exogenous, **kwargs)
 
         return_vals = est.predict_in_sample(
             exogenous=Xt, start=start, end=end,
             return_conf_int=return_conf_int,
-            alpha=alpha, typ=typ, dynamic=dynamic,
+            alpha=alpha, dynamic=dynamic,
             **predict_kwargs)
 
         return self._post_predict(
@@ -367,6 +367,7 @@ class Pipeline(BaseEstimator):
             The confidence intervals for the forecasts. Only returned if
             ``return_conf_int`` is True.
         """
+        kwargs = _warn_for_deprecated(**kwargs)
         Xt, est, predict_kwargs = self._pre_predict(
             n_periods, exogenous, **kwargs)
 

--- a/pmdarima/preprocessing/endog/__init__.py
+++ b/pmdarima/preprocessing/endog/__init__.py
@@ -3,4 +3,6 @@
 from .boxcox import *
 from .log import *
 
-__all__ = [s for s in dir() if not s.startswith("_")]
+# don't want to accidentally hoist `base` to top-level, since preprocessing has
+# its own base
+__all__ = [s for s in dir() if not (s.startswith("_") or s == 'base')]

--- a/pmdarima/preprocessing/endog/tests/test_base.py
+++ b/pmdarima/preprocessing/endog/tests/test_base.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from pmdarima.compat.pytest import pytest_error_str
+from pmdarima.preprocessing.endog import LogEndogTransformer
+
+
+def test_value_error_on_check():
+    trans = LogEndogTransformer()  # could be anything, just need an instance
+    with pytest.raises(ValueError) as ve:
+        trans._check_y_exog(None, None)
+    assert 'non-None' in pytest_error_str(ve)

--- a/pmdarima/preprocessing/endog/tests/test_boxcox.py
+++ b/pmdarima/preprocessing/endog/tests/test_boxcox.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_array_almost_equal
 from scipy import stats
 import pytest
 
+from pmdarima.compat.pytest import pytest_error_str
 from pmdarima.preprocessing import BoxCoxEndogTransformer
 
 loggamma = stats.loggamma.rvs(5, size=500) + 5
@@ -37,6 +38,13 @@ def test_invertible_when_lambda_is_0():
     y_t, _ = trans.fit_transform(y)
     y_prime, _ = trans.inverse_transform(y_t)
     assert_array_almost_equal(y, y_prime)
+
+
+def test_value_error_on_neg_lambda():
+    trans = BoxCoxEndogTransformer(lmbda2=-4.)
+    with pytest.raises(ValueError) as ve:
+        trans.fit_transform([1, 2, 3])
+    assert 'lmbda2 must be a non-negative' in pytest_error_str(ve)
 
 
 class TestNonInvertibleBC:

--- a/pmdarima/preprocessing/exog/__init__.py
+++ b/pmdarima/preprocessing/exog/__init__.py
@@ -2,4 +2,6 @@
 
 from .fourier import *
 
-__all__ = [s for s in dir() if not s.startswith("_")]
+# don't want to accidentally hoist `base` to top-level, since preprocessing has
+# its own base
+__all__ = [s for s in dir() if not (s.startswith("_") or s == 'base')]

--- a/pmdarima/preprocessing/exog/tests/test_base.py
+++ b/pmdarima/preprocessing/exog/tests/test_base.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from pmdarima.preprocessing.exog import base
+from pmdarima import datasets
+import numpy as np
+import pandas as pd
+
+wineind = datasets.load_wineind()
+
+
+class RandomExogFeaturizer(base.BaseExogFeaturizer):
+    """Creates random exog features. This is just used to test base func"""
+
+    def _get_prefix(self):
+        return "RND"
+
+    def fit(self, y, exogenous):
+        return self
+
+    def transform(self, y, exogenous=None, n_periods=0, **_):
+        exog = np.random.rand(y.shape[0], 4)
+        exog = self._safe_hstack(exogenous, exog)
+        return y, exog
+
+
+def test_default_get_feature_names():
+    feat = RandomExogFeaturizer()
+    y_trans, exog = feat.fit_transform(wineind)
+    assert y_trans is wineind
+    assert exog.columns.tolist() == \
+        ['RND_0', 'RND_1', 'RND_2', 'RND_3']
+
+
+def test_default_get_feature_names_with_exog():
+    feat = RandomExogFeaturizer()
+    exog = pd.DataFrame.from_records(np.random.rand(wineind.shape[0], 2),
+                                     columns=['a', 'b'])
+    y_trans, exog_trans = feat.fit_transform(wineind, exog)
+    assert y_trans is wineind
+    assert exog_trans.columns.tolist() == \
+        ['a', 'b', 'RND_0', 'RND_1', 'RND_2', 'RND_3']

--- a/pmdarima/preprocessing/exog/tests/test_fourier.py
+++ b/pmdarima/preprocessing/exog/tests/test_fourier.py
@@ -4,9 +4,12 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from pmdarima.preprocessing.exog import FourierFeaturizer
+from pmdarima.compat.pytest import pytest_error_str
 import pmdarima as pm
 
 import pytest
+
+wineind = pm.datasets.load_wineind()
 
 
 class TestFourierREquivalency:
@@ -124,3 +127,17 @@ def test_update_transform():
     _, xreg2 = trans.transform(y)
     assert_array_almost_equal(xreg2[:100], xreg)
     assert_array_almost_equal(xreg2[100:], Xt)
+
+
+def test_value_error_check():
+    feat = FourierFeaturizer(m=12)
+    with pytest.raises(ValueError) as ve:
+        feat._check_y_exog(wineind, None, null_allowed=False)
+    assert 'non-None' in pytest_error_str(ve)
+
+
+def test_value_error_on_fit():
+    feat = FourierFeaturizer(m=12, k=8)
+    with pytest.raises(ValueError) as ve:
+        feat.fit_transform(wineind)
+    assert 'k must be' in pytest_error_str(ve)

--- a/pmdarima/preprocessing/tests/test_base.py
+++ b/pmdarima/preprocessing/tests/test_base.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from pmdarima.preprocessing import base
+from pmdarima.compat.pytest import pytest_error_str
+
+
+def test_value_error_on_update_check():
+    with pytest.raises(ValueError) as ve:
+        base.UpdatableMixin()._check_endog(None)
+    assert 'cannot be None' in pytest_error_str(ve)

--- a/pmdarima/tests/test_pipeline.py
+++ b/pmdarima/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pmdarima.compat.pytest import pytest_error_str
-from pmdarima.pipeline import Pipeline
+from pmdarima.pipeline import Pipeline, _warn_for_deprecated
 from pmdarima.preprocessing import BoxCoxEndogTransformer, FourierFeaturizer
 from pmdarima.arima import ARIMA, AutoARIMA
 from pmdarima.datasets import load_wineind
@@ -110,6 +110,7 @@ def test_get_kwargs(pipe, kwargs, expected):
 def test_pipeline_behavior():
     pipeline = Pipeline([
         ("fourier", FourierFeaturizer(m=12)),
+        ("boxcox", BoxCoxEndogTransformer()),
         ("arima", AutoARIMA(seasonal=False, stepwise=True,
                             suppress_warnings=True, d=1, max_p=2, max_q=0,
                             start_q=0, start_p=1,
@@ -117,7 +118,7 @@ def test_pipeline_behavior():
     ])
 
     # Quick assertions on indexing
-    assert len(pipeline) == 2
+    assert len(pipeline) == 3
 
     pipeline.fit(train)
     preds = pipeline.predict(5)
@@ -205,3 +206,11 @@ def test_pipeline_predict_inverse_transform(pipeline, exog, inverse_transform,
 
     if return_conf_ints:
         assert isinstance(in_sample, tuple) and len(in_sample) == 2
+
+
+def test_deprecation_warning():
+    kwargs = {'typ': 'foo'}
+    with pytest.warns(DeprecationWarning) as we:
+        kwargs = _warn_for_deprecated(**kwargs)
+    assert not kwargs
+    assert we


### PR DESCRIPTION
This is related to #231 and backs out some more deprecated args. It does not break any backwards compatibility, instead just being noisy with `DeprecationWarning`s for now.