### PR TITLE
[MRG + 1] Fix doc typo

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -56,8 +56,8 @@ v0.8.1) will document the latest features.
   [1] These can still be passed to the ``fit`` method via ``**fit_kwargs``, but should
   no longer be passed to the model constructor.
 
-* Added `diff_env` function that is in parity with R's implementation,
-  `diffenv <https://stat.ethz.ch/R-manual/R-devel/library/stats/html/diffinv.html>`_,
+* Added `diff_inv` function that is in parity with R's implementation,
+  `diffinv <https://stat.ethz.ch/R-manual/R-devel/library/stats/html/diffinv.html>`_,
   as requested in `#180 <https://github.com/tgsmith61591/pmdarima/issues/180>`_.
 
 `v1.4.0 <http://alkaline-ml.com/pmdarima/1.4.0/>`_


### PR DESCRIPTION
<!-- Please prefix your title with one of the following:

[WIP] - If the pull request is not finalized
[MRG] - If you are ready to have this PR looked at by a project maintainer

-->

# Description

`diffinv` and `diff_inv` were incorrectly labeled as `diffenv` and `diff_env` in the docs from #236 

## Type of change

- [X] Documentation change

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have made corresponding changes to the documentation
